### PR TITLE
Altera domíno no CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,3 +1,3 @@
-pythonsudeste.org
-www.pythonsudeste.org
-2017.pythonsudeste.org
+pythonsul.org
+www.pythonsul.org
+2017.pythonsul.org


### PR DESCRIPTION
O domínio pythonsul.org não está respondendo a requisições HTTP. Essas alterações configuram o GitHub Pages, mas talvez seja necessária configuração de DNS do domínio também.